### PR TITLE
Fix type bug

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -60,6 +60,7 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
             doc_idx.append(item)
             return ":param %s_sphinx_paramlinks_%s.%s:" % (
                 modifier, objname, paramname)
+        
         def secondary_cvt(m):
             modifier, objname, paramname = m.group(1) or '', name, m.group(2)
             return ":type %s_sphinx_paramlinks_%s.%s:" % (

--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -60,7 +60,14 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
             doc_idx.append(item)
             return ":param %s_sphinx_paramlinks_%s.%s:" % (
                 modifier, objname, paramname)
-        return re.sub(r'^:param ([^:]+? )?([^:]+?):', cvt, line)
+        def secondary_cvt(m):
+            modifier, objname, paramname = m.group(1) or '', name, m.group(2)
+            return ":type %s_sphinx_paramlinks_%s.%s:" % (
+                modifier, objname, paramname)
+        
+        line = re.sub(r'^:param ([^:]+? )?([^:]+?):', cvt, line)
+        line = re.sub(r'^:type ([^:]+? )?([^:]+?):', secondary_cvt, line)
+        return line
 
     if what in ('function', 'method', 'class'):
         lines[:] = [_cvt_param(name, line) for line in lines]


### PR DESCRIPTION
Since you are temporarily renaming the param name to be prefixed with _sphinx_paramlink_ , any reference to this param by :type directive no longer works.

This is a crude fix, but my limited knowledge of sphinx plugin system prevents me to do more.

Hope you find it useful, and maybe create a proper fix for the problem and a new version. That would be a huge help.

Thanks,

Raz