### PR TITLE
avoid error on missing docname

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -49,7 +49,9 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
 
     idx = _tempdata(app)
 
-    docname = app.env.temp_data["docname"]
+    docname = app.env.temp_data.get("docname")
+    if not docname:
+        return
     if docname in idx:
         doc_idx = idx[docname]
     else:


### PR DESCRIPTION
Hi, 
I'm trying to use this extension but fail to run it in both Sphinx 2.4.4 and 3.0.0 versions (actually need both for different project requirements).

In both versions I run into error : 
```
Exception occurred:
  File "/home/travis/conda/lib/python3.7/site-packages/sphinx_paramlinks/sphinx_paramlinks.py", line 52, in autodoc_process_docstring
    docname = app.env.temp_data["docname"]
KeyError: 'docname'
```

This PR avoid running into the error.

