### PR TITLE
Make shortcut for referencing params of the current function work.

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -229,9 +229,15 @@ def lookup_params(app, env, node, contnode):
     # if we just have :paramref:`arg` and not :paramref:`namespace.arg`,
     # we must assume that the current namespace is meant.
     if tokens == [target]:
-        #  Let's extract it from the node's source and prepend it, if the source is available
-        if node.source and '.' in node.source:
-            tokens.insert(0, node.source.rsplit('.', maxsplit=1)[-1])
+        #
+        # node.source is expected to look like:
+        # /path/to/file.py:docstring of module.clsname.methname
+        #
+        docstring_match = re.match(r".*?:docstring of (.*)", node.source)
+        if docstring_match:
+            full_attr_path = docstring_match.group(1)
+            fn_name = full_attr_path.split(".")[-1]
+            tokens.insert(0, fn_name)
 
     resolve_target = ".".join(tokens[0:-1])
 


### PR DESCRIPTION
Closes #11. 

I built the slqachlemy docs with this change. It worked fine and I didn't see any additional warnings/errors. There are probably still some cases where this doesn't suffice but at least I'm rather sure that it doesn't make things worse :)