### PR TITLE
New settings for links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ This parameter accepts the following values:
   name (but before an eventual type specification). By default, this symbol
   only shows when hovering the parameter description (see below)
 
-* ``'both'``: link both the name and also generate a link symbol.
+* ``'name_and_symbol'``: link both the name and also generate a link symbol.
 
 The default is ``paramlinks_hyperlink_param = 'link_symbol'``.
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Just turn it on in ``conf.py``::
                 # ...
             ]
 
-You can modify how clickable hyperlinks are placed around the names of
+Since version 0.5.3, you can modify how clickable hyperlinks are placed around the names of
 the parameter using the ``paramlinks_hyperlink_param`` setting in ``conf.py``::
 
     paramlinks_hyperlink_param='name'
@@ -39,8 +39,6 @@ This parameter accepts the following values:
 * ``'both'``: link both the name and also generate a link symbol.
 
 The default is ``paramlinks_hyperlink_param = 'link_symbol'``.
-
-.. versionadded:: 0.5.3
 
 Features
 ========

--- a/README.rst
+++ b/README.rst
@@ -20,15 +20,27 @@ Just turn it on in ``conf.py``::
                 # ...
             ]
 
-Stylesheet
-==========
+You can modify how clickable hyperlinks are placed around the names of
+the parameter using the ``paramlinks_hyperlink_param`` setting in ``conf.py``::
 
-The paragraph link involves a short stylesheet, to allow the links to
-be visible when hovered.  This sheet is called
-``sphinx_paramlinks.css`` and the plugin will copy it to the ``_static``
-directory of the output automatically.   The stylesheet is added to the
-``css_files`` list present in the template namespace for Sphinx via the
-``Sphinx.add_stylesheet()`` hook.
+    paramlinks_hyperlink_param='name'
+
+This parameter accepts the following values:
+
+* ``'none'``: No link will be be inserted. The parameter still has a target
+  attached to it so that you can e.g. jump to it from the search.
+
+* ``'name'``: The parameter name is a clickable hyperlink.
+
+* ``'link_symbol'``: A clickable link symbol is inserted after the parameter
+  name (but before an eventual type specification). By default, this symbol
+  only shows when hovering the parameter description (see below)
+
+* ``'both'``: link both the name and also generate a link symbol.
+
+The default is ``paramlinks_hyperlink_param = 'link_symbol'``.
+
+.. versionadded:: 0.5.3
 
 Features
 ========
@@ -52,6 +64,43 @@ Features
 * The paramlinks are also added to the master index as well as the list
   of domain objects, which allows them to be searchable through the
   searchindex.js system.  (new in 0.3.0)
+
+Stylesheet
+==========
+
+The paragraph link involves a short stylesheet, to allow the links to
+be visible when hovered.  This sheet is called
+``sphinx_paramlinks.css`` and the plugin will copy it to the ``_static``
+directory of the output automatically. The stylesheet is added to the
+``css_files`` list present in the template namespace for Sphinx via the
+``Sphinx.add_stylesheet()`` hook.
+
+Customization
+-------------
+
+To customize the link styling, you can override the configuration of
+``sphinx_paramlinks.css`` by adding a custom style sheet via::
+
+     app.add_css_file("path/to/custom.css")
+
+If the parameter name is a hyperlink, the HTML code will look something like
+this::
+
+     <a class="paramname reference internal" href="#package.method.params.parameter_name">
+          <strong>parameter_name</strong>
+     </a>
+
+The class ``paramname`` is defined by ``sphinx-paramlinks`` and can be used to
+customize the styling.
+
+If a link symbol is inserted after the hyperlink, the HTML code will look
+something like this::
+
+     <a class="paramlink headerlink reference internal" href="#package.method.params.parameter_name">¶</a>
+
+The class ``paramlink`` is defined by ``sphinx-paramlinks`` and can be used to
+customize the styling.
+
 
 Compatibility
 =============

--- a/sphinx_paramlinks/sphinx_paramlinks.css
+++ b/sphinx_paramlinks/sphinx_paramlinks.css
@@ -7,3 +7,7 @@ p:hover > a.headerlink, p:hover > a.paramlink, li:hover > a.paramlink, li:hover 
    visibility: visible;
 }
 
+a.paramname {
+    color:inherit;
+}
+

--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -36,7 +36,7 @@ class HyperlinkStyle(Enum):
     NONE = "none"
     NAME = "name"
     LINK_SYMBOL = "link_symbol"
-    BOTH = "both"
+    NAME_AND_SYMBOL = "name_and_symbol"
 
 
 def _indexentries(env):
@@ -157,13 +157,19 @@ class LinkParams(Transform):
     default_priority = 210
 
     def apply(self):
-        config_value = self.document.settings.env.app.config.paramlinks_hyperlink_param
+        config_value = (
+            self.document.settings.env.app.config.paramlinks_hyperlink_param
+        )
         try:
             link_style = HyperlinkStyle[config_value.upper()]
         except KeyError as exc:
             raise ValueError(
-                f"Unknown value {repr(config_value)} for 'paramlinks_hyperlink_param'. "
-                f"Must be one of {', '.join(repr(member.value) for member in HyperlinkStyle)}."
+                f"Unknown value {repr(config_value)} for "
+                f"'paramlinks_hyperlink_param'. "
+                f"Must be one of "
+                f"""{
+                    ', '.join(repr(member.value) for member in HyperlinkStyle)
+                }."""
             ) from exc
 
         if link_style is HyperlinkStyle.NONE:
@@ -223,7 +229,7 @@ class LinkParams(Transform):
 
                     if link_style in (
                         HyperlinkStyle.NAME,
-                        HyperlinkStyle.BOTH,
+                        HyperlinkStyle.NAME_AND_SYMBOL,
                     ):
                         # If the parameter name should be a href, we wrap it
                         # into an <a></a> tag
@@ -244,7 +250,7 @@ class LinkParams(Transform):
 
                     if link_style in (
                         HyperlinkStyle.LINK_SYMBOL,
-                        HyperlinkStyle.BOTH,
+                        HyperlinkStyle.NAME_AND_SYMBOL,
                     ):
                         # If there should be a link symbol after the parameter
                         # name, insert it here
@@ -253,7 +259,7 @@ class LinkParams(Transform):
                             nodes.reference(
                                 "",
                                 "",
-                                nodes.Text(u"¶", u"¶"),
+                                nodes.Text("¶", "¶"),
                                 refid=refid,
                                 # paramlink is our own CSS class, headerlink
                                 # is theirs.  Trying to get everything we can

--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -157,11 +157,14 @@ class LinkParams(Transform):
     default_priority = 210
 
     def apply(self):
-        link_style = HyperlinkStyle[
-            (
-                self.document.settings.env.app
-            ).config.paramlinks_hyperlink_param.upper()
-        ]
+        config_value = self.document.settings.env.app.config.paramlinks_hyperlink_param
+        try:
+            link_style = HyperlinkStyle[config_value.upper()]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown value {repr(config_value)} for 'paramlinks_hyperlink_param'. "
+                f"Must be one of {', '.join(repr(member.value) for member in HyperlinkStyle)}."
+            ) from exc
 
         if link_style is HyperlinkStyle.NONE:
             return


### PR DESCRIPTION
Hi. After #12, I finally got around to play around with this more and would like to propose two additions:

<details>
  <summary>This part was moved to #14</summary>

1. Better support for nitpicky mode. Currently, `:paramref:` is resolved without checking if the resulting target exists. By checking against the index created in `build_index` within `lookup_params` and returning `None` if the target doesn't exist, we give sphinx a chance to emit a warning about an unresolved reference, if needed. This minimal-effort approach has two downsides: First, the `_sphinx_paramlinks_` prefix is still included in the warning, e.g.

    <pre>path\to\python-telegram-bot\telegram\ext\_basepersistence.py:docstring of telegram.ext._basepersistence.BasePersistence.insert_bot:1: WARNING: py:paramref reference target not found: _sphinx_paramlinks_bot</pre> 

    Secondly, I don't know how well it plays with the [`nitpick_ignore`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore) and `nitpick_ignore_regex` settings (I guess the prefix could mean trouble here)
    Alternatively, one could add an event handler for the [`warn-missing-reference`](https://www.sphinx-doc.org/en/master/extdev/appapi.html?highlight=missing-reference#event-warn-missing-reference) event, but the [built-in logic](https://github.com/sphinx-doc/sphinx/blob/80b0a16e1c5f7266522a50284a003a0e17cf5ff7/sphinx/transforms/post_transforms/__init__.py#L170-L208) of that is actually somewhat elaborate. At least for me, adapting this for sphinx-paramlinks is not worth the effort - I can live with the prefix and so far I don't use the `nitpick_ignore` settings

</details>

---

2. Add options to a) turn off the insertion of the link symbol after the parameter name and b) to make the parameter name itself the link. This idea came up at https://github.com/python-telegram-bot/python-telegram-bot/pull/2798#discussion_r759343953. The reason is that with the link symbol only showing on hover, there is a large gap between parameter name & description/type. But showing the link symbol just all the time also doesn't look __too__ good:

    ![image](https://user-images.githubusercontent.com/22366557/144278517-5f991d49-ebf1-47fc-824d-342c39581f41.png)

    that built is currently available [here](https://python-telegram-bot.readthedocs.io/en/docs-referencing/telegram.bot.html#telegram.Bot.add_sticker_to_set.params.user_id)

If you like the general idea of those changes, I'm happy to discuss the implementation :) I can also split this PR up into two for the two different parts if you like that better.

Cheers!