### PR TITLE
Better support for nitpicky mode

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -281,11 +281,15 @@ def lookup_params(app, env, node, contnode):
 
     if newnode is not None:
         # assuming we found it, tack the paramname back onto to the final
-        # URI.
+        # URI, if it exists in the index.
         if "refuri" in newnode:
             newnode["refuri"] += ".params." + paramname
+            if not app.env.domains["py"].data["objects"].get(newnode["refuri"].split('#')[-1]):
+                return
         elif "refid" in newnode:
             newnode["refid"] += ".params." + paramname
+            if not app.env.domains["py"].data["objects"].get(newnode["refid"].split('#')[-1]):
+                return
 
     return newnode
 


### PR DESCRIPTION
Spin-off of #13: Better support for nitpicky mode.

Currently, `:paramref:` is resolved without checking if the resulting target exists. By checking against the index created in `build_index` within `lookup_params` and returning `None` if the target doesn't exist, we give sphinx a chance to emit a warning about an unresolved reference, if needed. This minimal-effort approach has two downsides:

First, the `_sphinx_paramlinks_` prefix is still included in the warning, e.g.

```python
path\to\python-telegram-bot\telegram\ext\_basepersistence.py:docstring of telegram.ext._basepersistence.BasePersistence.insert_bot:1: WARNING: py:paramref reference target not found: _sphinx_paramlinks_bot
```
Secondly, I don't know how well it plays with the [`nitpick_ignore`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore) and `nitpick_ignore_regex` settings (I guess the prefix could mean trouble here)

Alternatively, one could add an event handler for the [`warn-missing-reference`](https://www.sphinx-doc.org/en/master/extdev/appapi.html?highlight=missing-reference#event-warn-missing-reference) event, but the [built-in logic](https://github.com/sphinx-doc/sphinx/blob/80b0a16e1c5f7266522a50284a003a0e17cf5ff7/sphinx/transforms/post_transforms/__init__.py#L170-L208) for that is actually somewhat elaborate. At least for me, adapting this for sphinx-paramlinks is not worth the effort - I can live with the prefix and so far I don't use the `nitpick_ignore` settings
