### PR TITLE
Handle `:kwarg:` arguments

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -73,7 +73,7 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
             name = name[0:-9]
 
         def cvt(m):
-            modifier, objname, paramname = m.group(1) or "", name, m.group(2)
+            role, modifier, objname, paramname = m.group(1), m.group(2) or "", name, m.group(3)
             refname = _refname_from_paramname(paramname, strip_markup=True)
             item = (
                 "single",
@@ -85,22 +85,24 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
                 item += (None,)
 
             doc_idx.append(item)
-            return ":param %s_sphinx_paramlinks_%s.%s:" % (
+            return ":%s %s_sphinx_paramlinks_%s.%s:" % (
+                role,
                 modifier,
                 objname,
                 paramname,
             )
 
         def secondary_cvt(m):
-            modifier, objname, paramname = m.group(1) or "", name, m.group(2)
-            return ":type %s_sphinx_paramlinks_%s.%s:" % (
+            role, modifier, objname, paramname = m.group(1), m.group(2) or "", name, m.group(3)
+            return ":%s %s_sphinx_paramlinks_%s.%s:" % (
+                role,
                 modifier,
                 objname,
                 paramname,
             )
 
-        line = re.sub(r"^:param ([^:]+? )?([^:]+?):", cvt, line)
-        line = re.sub(r"^:type ([^:]+? )?([^:]+?):", secondary_cvt, line)
+        line = re.sub(r"^:(kwarg|param) ([^:]+? )?([^:]+?):", cvt, line)
+        line = re.sub(r"^:(kwtype|type) ([^:]+? )?([^:]+?):", secondary_cvt, line)
         return line
 
     if what in ("function", "method", "class"):


### PR DESCRIPTION
Hi again :)

In https://github.com/python-telegram-bot/python-telegram-bot/pull/3010 it was notices that `sphinx-paramlinks` doesn't work with [napoleons](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html?highlight=napoleon) "Keyword Arguments" - see e.g. [here](https://docs.python-telegram-bot.org/en/latest/telegram.bot.html#telegram.Bot.add_sticker_to_set) for how we use that to differentiate between positional and keyword-only arguments.  See [the docs of napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#confval-napoleon_use_keyword), https://github.com/sphinx-doc/sphinx/issues/2379 and https://github.com/sphinx-doc/sphinx/pull/2381 for more info on how "Keyword Arguments" are implemented in sphinx.

However this seems to be rather easy to support by just enhancing two regexes a bit. A test on our documentation seemed to work fine.