### PR TITLE
Fix regex for keyword arguments

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -101,7 +101,7 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):
                 paramname,
             )
 
-        line = re.sub(r"^:(kwarg|param) ([^:]+? )?([^:]+?):", cvt, line)
+        line = re.sub(r"^:(keyword|param) ([^:]+? )?([^:]+?):", cvt, line)
         line = re.sub(r"^:(kwtype|type) ([^:]+? )?([^:]+?):", secondary_cvt, line)
         return line
 


### PR DESCRIPTION
Well, this is embarassing 😬 I had tested the changes by directly editing the corresponding file in my venv and then made this rookie mistake while copying the changes to my fork. I double checked again and this is now working as expected. I'm really sorry for the keyword :/