### PR TITLE
Adjust the regex to accept source of a node without a path

### DIFF
--- a/sphinx_paramlinks/sphinx_paramlinks.py
+++ b/sphinx_paramlinks/sphinx_paramlinks.py
@@ -301,8 +301,12 @@ def lookup_params(app, env, node, contnode):
         #
         # node.source is expected to look like:
         # /path/to/file.py:docstring of module.clsname.methname
+        # or:
+        # docstring of module.clsname.methname
         #
-        docstring_match = re.match(r".*?:docstring of (.*)", node.source)
+        # as the path component can be optional - we use non-capturing group (?:<regex>)
+        # to potentially discard it.
+        docstring_match = re.match(r"(?:.*?:|^)docstring of (.*)", node.source)
         if docstring_match:
             full_attr_path = docstring_match.group(1)
             fn_name = full_attr_path.split(".")[-1]


### PR DESCRIPTION
Hi, I appreciate the work done in this extension, I recently integrated it in [NVIDIA DALI](https://github.com/NVIDIA/DALI/) docs.

In DALI, we generated our main API submodule tree in runtime. We have a `nvidia/dali/fn/__init__.py` which is the entry point for `nvidia.dali.fn` API, but submodules like `nvidia.dali.fn.decoders` don't have corresponding files and are created in runtime (when library is loaded we query the C++ backend for that structure).

When I logged the `source` member of the sphinx node corresponding to the functions in those modules, for the top level API I get:
```
node.source='/home/klecki/.local/lib/python3.10/site-packages/nvidia/dali/fn/__init__.py:docstring of nvidia.dali.fn.pad'
```
but for the submodule I see just:
```
node.source='docstring of nvidia.dali.fn.decoders.image_slice'
```
Missing the `/path/to/file.py:` part (note the `:` is missing)

I guess it's similar to:
```
>>> nvidia.dali.fn
<module 'nvidia.dali.fn' from '/home/klecki/.local/lib/python3.10/site-packages/nvidia/dali/fn/__init__.py'>
>>> nvidia.dali.fn.decoders
<module 'nvidia.dali.fn.decoders' (<_frozen_importlib_external._NamespaceLoader object at 0x7fffd67be290>)>
```

The regex in this line for the `missing-reference` resolver assumes that the `:` is there: https://github.com/sqlalchemyorg/sphinx-paramlinks/blob/main/sphinx_paramlinks/sphinx_paramlinks.py#L305

I was able to work around this by creating a `missing-reference` resolver with higher priority to inject `:` into the `source` member before calling the sphinx_paramlinks back: https://github.com/NVIDIA/DALI/pull/5723 - but in the end I realized it's easier to 
inject the full absolute reference to the parameter while processing the docstring in `autodoc-process-docstring` hook: https://github.com/NVIDIA/DALI/pull/5725/ 
(Our `autodoc-process-docstring` hook detects parameters surrounded by single backticks, checks if they appear in the current object's signature, and if so appends the `:paramref:` directive ahead of them, allowing more concise Python docstring and clickable links for parameter references in Sphinx).

Although I worked around the problem I still think someone else might hit it, so I propose to relax the regex.

